### PR TITLE
Do not crash if cannot found key templatedisplaytext

### DIFF
--- a/cloudstack-instancereport.py
+++ b/cloudstack-instancereport.py
@@ -273,7 +273,10 @@ def get_stats(args):
             vmserviceofferingid = virtualmachine["serviceofferingid"]
             vmserviceofferingname = virtualmachine["serviceofferingname"]
             vmtemplateid = virtualmachine["templateid"]
-            vmtemplatedisplaytext = virtualmachine["templatedisplaytext"]
+            try:
+                vmtemplatedisplaytext = virtualmachine["templatedisplaytext"]
+            except KeyError:
+                vmtemplatedisplaytext = "Not found"
             vmzoneid = virtualmachine["zoneid"]
             vmzonename = virtualmachine["zonename"]
             vmipaddress = []


### PR DESCRIPTION
If templatedisplay is not found the text is replaced by "Not found".
The script is not crashing after that.